### PR TITLE
Fix plugin loading issues when working with minified files

### DIFF
--- a/lib/color.js
+++ b/lib/color.js
@@ -214,14 +214,11 @@ color.installColorSpace = function (colorSpaceName, propertyNames, config) {
     return color;
 };
 
-color.pluginByName = {};
+color.pluginList = [];
 
 color.use = function (plugin) {
-    var pluginName = plugin.name;
-    if (pluginName === '')
-        pluginName = 'anonymous' + Object.keys(this.pluginByName).length;
-    if (typeof pluginName !== 'string' || !this.pluginByName[pluginName]) {
-        this.pluginByName[pluginName] = plugin;
+    if (color.pluginList.indexOf(plugin) === -1) {
+        this.pluginList.push(plugin);
         plugin(color);
     }
     return color;

--- a/lib/color.js
+++ b/lib/color.js
@@ -218,6 +218,8 @@ color.pluginByName = {};
 
 color.use = function (plugin) {
     var pluginName = plugin.name;
+    if (pluginName === '')
+        pluginName = 'anonymous' + Object.keys(this.pluginByName).length;
     if (typeof pluginName !== 'string' || !this.pluginByName[pluginName]) {
         this.pluginByName[pluginName] = plugin;
         plugin(color);


### PR DESCRIPTION
Here's a fix for an important bug that prevent OneColor from being correctly initialized when bundled inside minified files. Basically, since you rely on `Function.name` to detect plugin names, then it breaks as soon as those names are removed.

A quick and dirty fix is to handle empty function names with. A better fix would be to stop relying on Function.name, and to explicitely pass the plugins names in the `.use()` arguments instead.
