### PR TITLE
Replace browserify with rollup. Also test generated bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   directories:
   - node_modules
 node_js:
-  - "0.10"
   - "0.12"
   - "1"
   - "2"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Package managers:
 * npm: `npm install onecolor`
 * bower: `bower install color`
 
+Small sizes:
+* one-color.js ![](http://img.badgesize.io/One-com/one-color/master/one-color.js.svg?label=size) ![](http://img.badgesize.io/One-com/one-color/master/one-color.js.svg?label=gzip&compression=gzip) (Basic RGB, HSV, HSL)
+* one-color-all.js ![](http://img.badgesize.io/One-com/one-color/master/one-color-all.js.svg?label=size) ![](http://img.badgesize.io/One-com/one-color/master/one-color-all.js.svg?label=gzip&compression=gzip) (Full RGB, HSV, HSL, CMYK, XYZ, LAB, named colors, [helper functions](https://github.com/One-com/one-color/tree/master/lib/plugins))
+
 
 Usage
 -----

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     }
   ],
   "devDependencies": {
-    "browserify": "13.0.0",
-    "bundle-collapser": "1.2.1",
     "coveralls": "2.11.9",
     "istanbul": "0.4.2",
     "jshint": "^2.9.1",
-    "minifyify": "7.3.2",
     "mocha": "2.4.5",
     "mocha-lcov-reporter": "1.2.0",
+    "rollup": "0.41.6",
+    "rollup-plugin-commonjs": "8.0.2",
+    "uglify-js": "2.8.21",
     "unexpected": "10.11.1"
   },
   "engines": {
@@ -47,12 +47,14 @@
     "lib"
   ],
   "scripts": {
-    "build": "browserify -p bundle-collapser/plugin -p [ minifyify --map one-color-all.map --output one-color-all.map ] --debug -e index -s one.color > one-color-all.js && browserify -p bundle-collapser/plugin -p [ minifyify --map one-color.map --output one-color.map ] --debug -e minimal -s one.color > one-color.js",
-    "preversion": "npm run lint && npm run build && npm test && bash -c 'git add one-color{-all,}.{js,map}'",
+    "one-color-all": "rollup -c rollup.config.js index.js && uglifyjs --compress --mangle --in-source-map OUT.js.map --source-map one-color-all.map OUT.js > one-color-all.js; rm OUT.*",
+    "one-color": "rollup -c rollup.config.js minimal.js && uglifyjs --compress --mangle --in-source-map OUT.js.map --source-map one-color.map OUT.js > one-color.js; rm OUT.*",
+    "build": "npm run one-color && npm run one-color-all",
+    "preversion": "npm run lint && npm run build && TEST_BUNDLES=true npm test && bash -c 'git add one-color{-all,}.{js,map}'",
     "lint": "jshint .",
     "test": "npm run lint && mocha",
     "coverage": "istanbul cover _mocha -- --reporter dot",
-    "travis": "npm run lint && npm run build && npm run coverage"
+    "travis": "npm run lint && npm run build && TEST_BUNDLES=true npm run coverage"
   },
   "jspm": {
     "dependencies": {},

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,14 @@
+var commonjs = require('rollup-plugin-commonjs');
+
+module.exports = {
+  // entry: 'index.js',
+  format: 'umd',
+  moduleName: 'one.color',
+  dest: 'OUT.js',
+
+  sourceMap: true,
+
+  plugins: [
+    commonjs()
+  ]
+};

--- a/test/color.js
+++ b/test/color.js
@@ -1,5 +1,19 @@
 var expect = require('unexpected');
-var color = require('../');
+var libs = [
+    {
+        name: 'index.js',
+        lib: require('../')
+    }
+];
+
+if (process.env.TEST_BUNDLES) {
+    libs.push({
+        name: 'Bundle: one-color-all.js',
+        lib: require('../one-color-all')
+    });
+}
+
+
 var namedColorSamples = require('./samples');
 
 var spaces = [
@@ -29,151 +43,158 @@ var spaces = [
     // }
 ];
 
+function testLib(libConfig) {
+    var color = libConfig.lib;
 
-describe('Named colors', function () {
-    Object.keys(namedColorSamples).forEach(function (namedColor) {
-        var hex = namedColorSamples[namedColor].toLowerCase();
-        it('should parse ' + namedColor + ' as ' + hex, function () {
-            return expect(color(namedColor).hex(), 'to be', hex);
-        });
-    });
-});
+    describe(libConfig.name, function () {
 
-spaces.forEach(function (colorSpace) {
-    describe(colorSpace.name, function () {
-        var spaceName = colorSpace.name;
-
-        it('should have a constructor function', function () {
-            expect(color[spaceName], 'to be a function');
-        });
-
-        var clr = colorSpace.name === 'CMYK' ? new color[spaceName](1, 1, 1, 1, 1) : new color[spaceName](0, 0, 0, 1);
-
-        it('should be constructed correctly', function () {
-            expect(clr, 'to satisfy', {
-                isColor: true
+        describe('Named colors', function () {
+            Object.keys(namedColorSamples).forEach(function (namedColor) {
+                var hex = namedColorSamples[namedColor].toLowerCase();
+                it('should parse ' + namedColor + ' as ' + hex, function () {
+                    return expect(color(namedColor).hex(), 'to be', hex);
+                });
             });
         });
 
-        describe('color space conversion', function () {
-            spaces.forEach(function (otherSpace) {
+        spaces.forEach(function (colorSpace) {
+            describe(colorSpace.name, function () {
+                var spaceName = colorSpace.name;
 
-                it('should have a ' + otherSpace.name + ' conversion method', function () {
-                    var expected = {};
-
-                    expected[otherSpace.name.toLowerCase()] = expect.it('to be a function');
-
-                    expect(clr, 'to satisfy', expected);
+                it('should have a constructor function', function () {
+                    expect(color[spaceName], 'to be a function');
                 });
 
-                it('should convert to ' + otherSpace.name, function () {
-                    var expected = {
+                var clr = colorSpace.name === 'CMYK' ? new color[spaceName](1, 1, 1, 1, 1) : new color[spaceName](0, 0, 0, 1);
+
+                it('should be constructed correctly', function () {
+                    expect(clr, 'to satisfy', {
                         isColor: true
-                    };
-
-                    otherSpace.channels.forEach(function (channelName) {
-                        expected['_' + channelName] = expect.it('to be a number');
                     });
-
-                    expect(clr[otherSpace.name.toLowerCase()](), 'to satisfy', expected);
-
-                    // Awaiting unexpected patch
-                    // expect(clr[otherSpace.name.toLowerCase()](), 'to exhaustively satisfy', expected);
                 });
-            });
-        });
 
-        describe('equality', function () {
-            it('should have an equals method', function () {
-                expect(clr, 'to satisfy', {
-                    equals: expect.it('to be a function').and('to have arity', 2)
+                describe('color space conversion', function () {
+                    spaces.forEach(function (otherSpace) {
+
+                        it('should have a ' + otherSpace.name + ' conversion method', function () {
+                            var expected = {};
+
+                            expected[otherSpace.name.toLowerCase()] = expect.it('to be a function');
+
+                            expect(clr, 'to satisfy', expected);
+                        });
+
+                        it('should convert to ' + otherSpace.name, function () {
+                            var expected = {
+                                isColor: true
+                            };
+
+                            otherSpace.channels.forEach(function (channelName) {
+                                expected['_' + channelName] = expect.it('to be a number');
+                            });
+
+                            expect(clr[otherSpace.name.toLowerCase()](), 'to satisfy', expected);
+
+                            // Awaiting unexpected patch
+                            // expect(clr[otherSpace.name.toLowerCase()](), 'to exhaustively satisfy', expected);
+                        });
+                    });
                 });
-            });
 
-            spaces.forEach(function (otherSpace) {
-                it('should equal same color in ' + otherSpace.name, function () {
-                    if (otherSpace.name === 'CMYK') {
-                        expect(clr.equals(new color[otherSpace.name](1, 1, 1, 1, 1)), 'to be true');
-                    } else {
-                        expect(clr.equals(new color[otherSpace.name](0, 0, 0, 1)), 'to be true');
-                    }
+                describe('equality', function () {
+                    it('should have an equals method', function () {
+                        expect(clr, 'to satisfy', {
+                            equals: expect.it('to be a function').and('to have arity', 2)
+                        });
+                    });
+
+                    spaces.forEach(function (otherSpace) {
+                        it('should equal same color in ' + otherSpace.name, function () {
+                            if (otherSpace.name === 'CMYK') {
+                                expect(clr.equals(new color[otherSpace.name](1, 1, 1, 1, 1)), 'to be true');
+                            } else {
+                                expect(clr.equals(new color[otherSpace.name](0, 0, 0, 1)), 'to be true');
+                            }
+                        });
+                    });
                 });
-            });
-        });
 
-        it('should convert to JSON', function () {
-            var clr = new color[colorSpace.name](Math.random(), Math.random(), Math.random(), Math.random(), Math.random());
+                it('should convert to JSON', function () {
+                    var clr = new color[colorSpace.name](Math.random(), Math.random(), Math.random(), Math.random(), Math.random());
 
-            expect(clr.equals(color(clr.toJSON())), 'to be true');
-        });
+                    expect(clr.equals(color(clr.toJSON())), 'to be true');
+                });
 
-        describe('color channels', function () {
-            colorSpace.channels.forEach(function (channel) {
-                var shortHand = channel === 'black' ? 'k' : channel.charAt(0);
+                describe('color channels', function () {
+                    colorSpace.channels.forEach(function (channel) {
+                        var shortHand = channel === 'black' ? 'k' : channel.charAt(0);
 
-                describe(channel, function () {
-                    it('should have a "' + channel + '" method', function () {
-                        var expected = {};
+                        describe(channel, function () {
+                            it('should have a "' + channel + '" method', function () {
+                                var expected = {};
 
-                        expected[channel] = expect.it('to be a function').and('to have arity', 2);
+                                expected[channel] = expect.it('to be a function').and('to have arity', 2);
 
-                        expect(clr, 'to satisfy', expected);
-                    });
+                                expect(clr, 'to satisfy', expected);
+                            });
 
-                    it('should have a "' + shortHand + '" shorthand method', function () {
-                        var expected = {};
+                            it('should have a "' + shortHand + '" shorthand method', function () {
+                                var expected = {};
 
-                        expected[shortHand] = expect.it('to be a function').and('to have arity', 2);
+                                expected[shortHand] = expect.it('to be a function').and('to have arity', 2);
 
-                        expect(clr, 'to satisfy', expected);
-                    });
+                                expect(clr, 'to satisfy', expected);
+                            });
 
-                    it('should get the "' + channel + '" value', function () {
-                        expect(new color[colorSpace.name](0, 0, 0, 0, 0)[channel](), 'to be', 0);
-                    });
+                            it('should get the "' + channel + '" value', function () {
+                                expect(new color[colorSpace.name](0, 0, 0, 0, 0)[channel](), 'to be', 0);
+                            });
 
-                    it('should get the "' + channel + '" shorthand "' + shortHand + '" value', function () {
-                        expect(new color[colorSpace.name](0, 0, 0, 0, 0)[channel](), 'to be', 0);
-                    });
+                            it('should get the "' + channel + '" shorthand "' + shortHand + '" value', function () {
+                                expect(new color[colorSpace.name](0, 0, 0, 0, 0)[channel](), 'to be', 0);
+                            });
 
-                    it('should set the "' + channel + '" value', function () {
-                        expect(clr[channel](0)[channel](), 'to be', 0);
-                        expect(clr[channel](0.5)[channel](), 'to be', 0.5);
+                            it('should set the "' + channel + '" value', function () {
+                                expect(clr[channel](0)[channel](), 'to be', 0);
+                                expect(clr[channel](0.5)[channel](), 'to be', 0.5);
 
-                        if (channel === 'hue') {
-                            // Hue is considered a circle, and thus has periodic boundary conditions
-                            expect(clr[channel](1)[channel](), 'to be', 0);
-                            expect(clr[channel](-0.1)[channel](), 'to be', 0.9);
-                            expect(clr[channel](1.5)[channel](), 'to be', 0.5);
-                        } else {
-                            expect(clr[channel](1)[channel](), 'to be', 1);
-                            expect(clr[channel](-0.1)[channel](), 'to be', 0);
-                            expect(clr[channel](1.1)[channel](), 'to be', 1);
-                        }
-                    });
+                                if (channel === 'hue') {
+                                    // Hue is considered a circle, and thus has periodic boundary conditions
+                                    expect(clr[channel](1)[channel](), 'to be', 0);
+                                    expect(clr[channel](-0.1)[channel](), 'to be', 0.9);
+                                    expect(clr[channel](1.5)[channel](), 'to be', 0.5);
+                                } else {
+                                    expect(clr[channel](1)[channel](), 'to be', 1);
+                                    expect(clr[channel](-0.1)[channel](), 'to be', 0);
+                                    expect(clr[channel](1.1)[channel](), 'to be', 1);
+                                }
+                            });
 
-                    it('should set the "' + channel + '" shorthand "' + shortHand + '" value', function () {
-                        expect(clr[shortHand](0)[channel](), 'to be', 0);
-                        expect(clr[shortHand](0.5)[channel](), 'to be', 0.5);
+                            it('should set the "' + channel + '" shorthand "' + shortHand + '" value', function () {
+                                expect(clr[shortHand](0)[channel](), 'to be', 0);
+                                expect(clr[shortHand](0.5)[channel](), 'to be', 0.5);
 
-                        if (channel === 'hue') {
-                            // Hue is considered a circle, and thus has periodic boundary conditions
-                            expect(clr[shortHand](1)[channel](), 'to be', 0);
-                            expect(clr[shortHand](-0.1)[channel](), 'to be', 0.9);
-                            expect(clr[shortHand](1.5)[channel](), 'to be', 0.5);
-                        } else {
-                            expect(clr[shortHand](1)[channel](), 'to be', 1);
-                            expect(clr[shortHand](-0.1)[channel](), 'to be', 0);
-                            expect(clr[shortHand](1.1)[channel](), 'to be', 1);
-                        }
-                    });
+                                if (channel === 'hue') {
+                                    // Hue is considered a circle, and thus has periodic boundary conditions
+                                    expect(clr[shortHand](1)[channel](), 'to be', 0);
+                                    expect(clr[shortHand](-0.1)[channel](), 'to be', 0.9);
+                                    expect(clr[shortHand](1.5)[channel](), 'to be', 0.5);
+                                } else {
+                                    expect(clr[shortHand](1)[channel](), 'to be', 1);
+                                    expect(clr[shortHand](-0.1)[channel](), 'to be', 0);
+                                    expect(clr[shortHand](1.1)[channel](), 'to be', 1);
+                                }
+                            });
 
-                    it('should adjust the "' + channel + '" value', function () {
-                        expect(clr[channel](0)[channel](0.5, true)[channel](), 'to be', 0.5);
-                    });
+                            it('should adjust the "' + channel + '" value', function () {
+                                expect(clr[channel](0)[channel](0.5, true)[channel](), 'to be', 0.5);
+                            });
 
-                    it('should adjust the "' + channel + '", shorthand "' + shortHand + '" value', function () {
-                        expect(clr[channel](0)[shortHand](0.5, true)[channel](), 'to be', 0.5);
+                            it('should adjust the "' + channel + '", shorthand "' + shortHand + '" value', function () {
+                                expect(clr[channel](0)[shortHand](0.5, true)[channel](), 'to be', 0.5);
+                            });
+                        });
+
                     });
                 });
 
@@ -181,4 +202,7 @@ spaces.forEach(function (colorSpace) {
         });
 
     });
-});
+
+}
+
+libs.forEach(testLib);


### PR DESCRIPTION
Rollup removes all the module loading wrappers of browserify, which were adding a considerable overhead.

![1 bash-1](https://cloud.githubusercontent.com/assets/331790/24775258/510fa296-1b1c-11e7-9d8a-9208584e940d.png)

I also added testing of the built bundle as part of CI and `npm preversion`, just to be sure that the new bundle is working as it should